### PR TITLE
Update to latest SimpleInjector

### DIFF
--- a/source/Glimpse.SimpleInjector/Glimpse.SimpleInjector.csproj
+++ b/source/Glimpse.SimpleInjector/Glimpse.SimpleInjector.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Glimpse.SimpleInjector</RootNamespace>
     <AssemblyName>Glimpse.SimpleInjector</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
@@ -50,8 +52,8 @@
       <HintPath>packages\Glimpse.1.8.6\lib\net40\Glimpse.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector, Version=4.10.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>packages\SimpleInjector.4.10.2\lib\net40\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=5.0.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>packages\SimpleInjector.5.0.3\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/source/Glimpse.SimpleInjector/Glimpse.SimpleInjector.csproj
+++ b/source/Glimpse.SimpleInjector/Glimpse.SimpleInjector.csproj
@@ -50,9 +50,8 @@
       <HintPath>packages\Glimpse.1.8.6\lib\net40\Glimpse.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector, Version=4.0.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>packages\SimpleInjector.4.0.0\lib\net40\SimpleInjector.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SimpleInjector, Version=4.10.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>packages\SimpleInjector.4.10.2\lib\net40\SimpleInjector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/source/Glimpse.SimpleInjector/packages.config
+++ b/source/Glimpse.SimpleInjector/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Glimpse" version="1.8.6" targetFramework="net40" />
-  <package id="Glimpse.AspNet" version="1.9.2" targetFramework="net40" />
-  <package id="SimpleInjector" version="4.10.2" targetFramework="net40" />
+  <package id="Glimpse" version="1.8.6" targetFramework="net40" requireReinstallation="true" />
+  <package id="Glimpse.AspNet" version="1.9.2" targetFramework="net40" requireReinstallation="true" />
+  <package id="SimpleInjector" version="5.0.3" targetFramework="net45" />
 </packages>

--- a/source/Glimpse.SimpleInjector/packages.config
+++ b/source/Glimpse.SimpleInjector/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Glimpse" version="1.8.6" targetFramework="net40" />
   <package id="Glimpse.AspNet" version="1.9.2" targetFramework="net40" />
-  <package id="SimpleInjector" version="4.0.0" targetFramework="net40" />
+  <package id="SimpleInjector" version="4.10.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Need to get glimpse.simpleinjector working on latest which means I had to bump this to net45 (requirement from SimpleInjector). Did this move in two steps to make sure nothing broke.